### PR TITLE
feat: Flatten auth config

### DIFF
--- a/examples/demo/spin.toml
+++ b/examples/demo/spin.toml
@@ -8,44 +8,50 @@ description = "FTL MCP server for hosting MCP tools"
 
 [variables]
 tool_components = { default = "echo-rs,echo-ts,weather-rs,weather-ts" }
-# ========================================
-# Available auth provider configurations
-# ========================================
 
+# ========================================
+# Auth Gateway Configuration
+# ========================================
+# Authentication is DISABLED by default. To enable, set auth_enabled = "true"
+
+# Core auth settings
+auth_enabled = { default = "false" }
+auth_gateway_url = { default = "http://ftl-mcp-gateway.spin.internal/mcp-internal" }
+auth_trace_header = { default = "X-Trace-Id" }
+
+# Provider configuration (required when auth_enabled = "true")
+auth_provider_type = { default = "" }  # "authkit" or "oidc"
+auth_provider_issuer = { default = "" }
+auth_provider_audience = { default = "" }
+
+# OIDC-specific settings (only required for auth_provider_type = "oidc")
+auth_provider_name = { default = "" }
+auth_provider_jwks_uri = { default = "" }
+auth_provider_authorize_endpoint = { default = "" }
+auth_provider_token_endpoint = { default = "" }
+auth_provider_userinfo_endpoint = { default = "" }
+auth_provider_allowed_domains = { default = "" }  # comma-separated list
+
+# ========================================
+# Example configurations:
+# ========================================
 # AuthKit:
-# {
-#   "type": "authkit",
-#   "issuer": "https://your-tenant.authkit.app",
-#   "audience": "mcp-api"  // optional
-# }
-
-# Generic OIDC (Auth0, Keycloak, etc):
-# {
-#   "type": "oidc",
-#   "name": "auth0",
-#   "issuer": "https://your-domain.auth0.com",
-#   "jwks_uri": "https://your-domain.auth0.com/.well-known/jwks.json",
-#   "authorization_endpoint": "https://your-domain.auth0.com/authorize",
-#   "token_endpoint": "https://your-domain.auth0.com/oauth/token",
-#   "userinfo_endpoint": "https://your-domain.auth0.com/userinfo",  // optional
-#   "audience": "your-api-identifier",  // optional
-#   "allowed_domains": ["*.auth0.com"]  // optional
-# }
-# Auth gateway configuration - auth is DISABLED by default
-# To enable auth, set SPIN_VARIABLE_AUTH_CONFIG with your auth configuration or edit the block below.
-auth_config = { default = '''
-{
-  "mcp_gateway_url": "http://ftl-mcp-gateway.spin.internal/mcp-internal",
-  "trace_id_header": "X-Trace-Id",
-  "enabled": false,
-  "providers": [
-    {
-      "type": "authkit",
-      "issuer": "https://your-tenant.authkit.app"
-    }
-  ]
-}
-''' }
+#   auth_enabled = "true"
+#   auth_provider_type = "authkit"
+#   auth_provider_issuer = "https://your-tenant.authkit.app"
+#   auth_provider_audience = "mcp-api"  # optional
+#
+# Auth0:
+#   auth_enabled = "true"
+#   auth_provider_type = "oidc"
+#   auth_provider_name = "auth0"
+#   auth_provider_issuer = "https://your-domain.auth0.com"
+#   auth_provider_jwks_uri = "https://your-domain.auth0.com/.well-known/jwks.json"
+#   auth_provider_authorize_endpoint = "https://your-domain.auth0.com/authorize"
+#   auth_provider_token_endpoint = "https://your-domain.auth0.com/oauth/token"
+#   auth_provider_userinfo_endpoint = "https://your-domain.auth0.com/userinfo"  # optional
+#   auth_provider_audience = "your-api-identifier"  # optional
+#   auth_provider_allowed_domains = "*.auth0.com"  # optional
 
 # Main MCP endpoint - uses auth gateway which can be disabled via auth_config
 [[trigger.http]]
@@ -61,10 +67,21 @@ route = "/.well-known/oauth-authorization-server"
 component = "mcp"
 
 [component.mcp]
-source = { registry = "ghcr.io", package = "fastertools:ftl-auth-gateway", version = "0.0.4" }
+source = { registry = "ghcr.io", package = "fastertools:ftl-auth-gateway", version = "0.0.6" }
 allowed_outbound_hosts = ["http://*.spin.internal", "https://*.authkit.app"]
 [component.mcp.variables]
-auth_config = "{{ auth_config }}"
+auth_enabled = "{{ auth_enabled }}"
+auth_gateway_url = "{{ auth_gateway_url }}"
+auth_trace_header = "{{ auth_trace_header }}"
+auth_provider_type = "{{ auth_provider_type }}"
+auth_provider_issuer = "{{ auth_provider_issuer }}"
+auth_provider_audience = "{{ auth_provider_audience }}"
+auth_provider_name = "{{ auth_provider_name }}"
+auth_provider_jwks_uri = "{{ auth_provider_jwks_uri }}"
+auth_provider_authorize_endpoint = "{{ auth_provider_authorize_endpoint }}"
+auth_provider_token_endpoint = "{{ auth_provider_token_endpoint }}"
+auth_provider_userinfo_endpoint = "{{ auth_provider_userinfo_endpoint }}"
+auth_provider_allowed_domains = "{{ auth_provider_allowed_domains }}"
 
 # MCP Gateway - internal endpoint
 [[trigger.http]]

--- a/src/ftl-auth-gateway/Cargo.lock
+++ b/src/ftl-auth-gateway/Cargo.lock
@@ -184,7 +184,7 @@ dependencies = [
 
 [[package]]
 name = "ftl-auth-gateway"
-version = "0.0.4"
+version = "0.0.5"
 dependencies = [
  "anyhow",
  "base64",

--- a/src/ftl-auth-gateway/Cargo.lock
+++ b/src/ftl-auth-gateway/Cargo.lock
@@ -184,7 +184,7 @@ dependencies = [
 
 [[package]]
 name = "ftl-auth-gateway"
-version = "0.0.5"
+version = "0.0.6"
 dependencies = [
  "anyhow",
  "base64",

--- a/src/ftl-auth-gateway/Cargo.toml
+++ b/src/ftl-auth-gateway/Cargo.toml
@@ -2,7 +2,7 @@
 name = "ftl-auth-gateway"
 authors = ["FTL Contributors"]
 description = "Authentication gateway for FTL MCP servers using AuthKit"
-version = "0.0.5"
+version = "0.0.6"
 license = "Apache-2.0"
 rust-version = "1.70"
 edition = "2021"

--- a/src/ftl-auth-gateway/Cargo.toml
+++ b/src/ftl-auth-gateway/Cargo.toml
@@ -2,7 +2,7 @@
 name = "ftl-auth-gateway"
 authors = ["FTL Contributors"]
 description = "Authentication gateway for FTL MCP servers using AuthKit"
-version = "0.0.4"
+version = "0.0.5"
 license = "Apache-2.0"
 rust-version = "1.70"
 edition = "2021"

--- a/src/ftl-auth-gateway/Makefile
+++ b/src/ftl-auth-gateway/Makefile
@@ -4,6 +4,10 @@
 build:
 	cargo build --target wasm32-wasip1 --release
 
+# Build the component for publishing
+build-component:
+	cargo component build --target wasm32-wasip1 --release
+
 # Run tests
 test:
 	cargo test
@@ -32,7 +36,7 @@ release: clean
 	cargo build --target wasm32-wasip1 --release
 	@echo "Release build complete: target/wasm32-wasip1/release/ftl_auth_gateway.wasm"
 
-publish:
+publish: build-component
 	@VERSION=$$(cargo read-manifest | jq -r .version) && \
 	wkg oci push ghcr.io/fastertools/ftl-auth-gateway:$$VERSION target/wasm32-wasip1/release/ftl_auth_gateway.wasm
 	wkg oci push ghcr.io/fastertools/ftl-auth-gateway:latest target/wasm32-wasip1/release/ftl_auth_gateway.wasm

--- a/src/ftl-auth-gateway/Makefile
+++ b/src/ftl-auth-gateway/Makefile
@@ -8,9 +8,14 @@ build:
 build-component:
 	cargo component build --target wasm32-wasip1 --release
 
-# Run tests
-test:
+test-cargo:
 	cargo test
+
+test-spin:
+	spin test
+
+# Run tests
+test: test-cargo test-spin
 
 # Clean build artifacts
 clean:

--- a/src/ftl-auth-gateway/spin.toml
+++ b/src/ftl-auth-gateway/spin.toml
@@ -6,6 +6,21 @@ version = "0.0.1"
 authors = ["FTL Contributors"]
 description = "Authentication gateway for FTL MCP servers"
 
+[variables]
+# These defaults are used for spin test
+auth_enabled = { default = "true" }
+auth_gateway_url = { default = "http://test-gateway.internal/mcp-internal" }
+auth_trace_header = { default = "X-Trace-Id" }
+auth_provider_type = { default = "authkit" }
+auth_provider_issuer = { default = "https://test.authkit.app" }
+auth_provider_audience = { default = "" }
+auth_provider_jwks_uri = { default = "https://test.authkit.app/.well-known/jwks.json" }
+auth_provider_name = { default = "" }
+auth_provider_authorize_endpoint = { default = "" }
+auth_provider_token_endpoint = { default = "" }
+auth_provider_userinfo_endpoint = { default = "" }
+auth_provider_allowed_domains = { default = "" }
+
 [[trigger.http]]
 route = "/..."
 component = "ftl-auth-gateway"
@@ -18,9 +33,23 @@ command = "cargo build --target wasm32-wasip1 --release"
 workdir = "."
 watch = ["src/**/*.rs", "Cargo.toml"]
 [component.ftl-auth-gateway.variables]
-# Required: JSON configuration for authentication providers
-# Default is an empty provider list - must be configured for production use
-auth_config = ""
+# Core auth settings
+auth_enabled = "{{ auth_enabled }}"
+auth_gateway_url = "{{ auth_gateway_url }}"
+auth_trace_header = "{{ auth_trace_header }}"
+
+# Provider configuration
+auth_provider_type = "{{ auth_provider_type }}"
+auth_provider_issuer = "{{ auth_provider_issuer }}"
+auth_provider_audience = "{{ auth_provider_audience }}"
+
+# OIDC-specific settings
+auth_provider_name = "{{ auth_provider_name }}"
+auth_provider_jwks_uri = "{{ auth_provider_jwks_uri }}"
+auth_provider_authorize_endpoint = "{{ auth_provider_authorize_endpoint }}"
+auth_provider_token_endpoint = "{{ auth_provider_token_endpoint }}"
+auth_provider_userinfo_endpoint = "{{ auth_provider_userinfo_endpoint }}"
+auth_provider_allowed_domains = "{{ auth_provider_allowed_domains }}"
 
 # Test configuration
 [component.ftl-auth-gateway.tool.spin-test]

--- a/src/ftl-auth-gateway/src/config.rs
+++ b/src/ftl-auth-gateway/src/config.rs
@@ -9,13 +9,8 @@ use crate::providers::{AuthKitProvider, OidcProvider, OidcProviderConfig, Provid
 pub struct GatewayConfig {
     pub mcp_gateway_url: String,
     pub trace_id_header: String,
-    #[serde(default = "default_enabled")]
     pub enabled: bool,
-    pub providers: Vec<ProviderConfig>,
-}
-
-fn default_enabled() -> bool {
-    true
+    pub provider: Option<ProviderConfig>,
 }
 
 /// Provider configuration enum
@@ -48,27 +43,96 @@ pub enum ProviderConfig {
 impl GatewayConfig {
     /// Load configuration from Spin variables
     pub fn from_spin_vars() -> Result<Self> {
-        let config_json = variables::get("auth_config")
-            .context("Missing required 'auth_config' variable")?;
+        // Read core settings
+        let enabled = variables::get("auth_enabled")
+            .unwrap_or_else(|_| "false".to_string())
+            .parse::<bool>()
+            .unwrap_or(false);
+        
+        let mcp_gateway_url = variables::get("auth_gateway_url")
+            .unwrap_or_else(|_| "http://ftl-mcp-gateway.spin.internal/mcp-internal".to_string());
+        
+        let trace_id_header = variables::get("auth_trace_header")
+            .unwrap_or_else(|_| "X-Trace-Id".to_string());
 
-        if config_json.is_empty() {
-            // Return default config for tests
-            return Ok(Self {
-                mcp_gateway_url: "http://ftl-mcp-gateway.spin.internal/mcp-internal".to_string(),
-                trace_id_header: "X-Trace-Id".to_string(),
-                enabled: true,
-                providers: vec![],
-            });
+        // Read provider configuration
+        let provider_type = variables::get("auth_provider_type").unwrap_or_default();
+        
+        let provider = if provider_type.is_empty() {
+            None
+        } else {
+            Some(Self::load_provider_config(&provider_type)?)
+        };
+
+        Ok(Self {
+            mcp_gateway_url,
+            trace_id_header,
+            enabled,
+            provider,
+        })
+    }
+
+    /// Load provider configuration from variables
+    fn load_provider_config(provider_type: &str) -> Result<ProviderConfig> {
+        let issuer = variables::get("auth_provider_issuer")
+            .context("auth_provider_issuer is required when auth_provider_type is set")?;
+        
+        let audience = variables::get("auth_provider_audience")
+            .ok()
+            .filter(|s| !s.is_empty());
+
+        match provider_type {
+            "authkit" => {
+                let jwks_uri = variables::get("auth_provider_jwks_uri")
+                    .ok()
+                    .filter(|s| !s.is_empty());
+                
+                Ok(ProviderConfig::AuthKit {
+                    issuer,
+                    jwks_uri,
+                    audience,
+                })
+            }
+            "oidc" => {
+                let name = variables::get("auth_provider_name")
+                    .context("auth_provider_name is required for OIDC provider")?;
+                let jwks_uri = variables::get("auth_provider_jwks_uri")
+                    .context("auth_provider_jwks_uri is required for OIDC provider")?;
+                let authorization_endpoint = variables::get("auth_provider_authorize_endpoint")
+                    .context("auth_provider_authorize_endpoint is required for OIDC provider")?;
+                let token_endpoint = variables::get("auth_provider_token_endpoint")
+                    .context("auth_provider_token_endpoint is required for OIDC provider")?;
+                let userinfo_endpoint = variables::get("auth_provider_userinfo_endpoint")
+                    .ok()
+                    .filter(|s| !s.is_empty());
+                
+                let allowed_domains = variables::get("auth_provider_allowed_domains")
+                    .unwrap_or_default()
+                    .split(',')
+                    .filter(|s| !s.trim().is_empty())
+                    .map(|s| s.trim().to_string())
+                    .collect();
+
+                Ok(ProviderConfig::Oidc {
+                    name,
+                    issuer,
+                    jwks_uri,
+                    audience,
+                    authorization_endpoint,
+                    token_endpoint,
+                    userinfo_endpoint,
+                    allowed_domains,
+                })
+            }
+            _ => anyhow::bail!("Unknown auth provider type: {}. Expected 'authkit' or 'oidc'", provider_type)
         }
-
-        serde_json::from_str(&config_json).context("Failed to parse auth_config JSON")
     }
 
     /// Build provider registry from configuration
     pub fn build_registry(&self) -> ProviderRegistry {
         let mut registry = ProviderRegistry::new();
 
-        for provider_config in &self.providers {
+        if let Some(provider_config) = &self.provider {
             match provider_config {
                 ProviderConfig::AuthKit {
                     issuer,
@@ -114,59 +178,65 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_config_parsing() {
-        let json = r#"{
-            "mcp_gateway_url": "http://gateway.internal",
-            "trace_id_header": "X-Request-ID",
-            "enabled": true,
-            "providers": [
-                {
-                    "type": "authkit",
-                    "issuer": "https://example.authkit.app",
-                    "audience": "my-api"
-                },
-                {
-                    "type": "oidc",
-                    "name": "auth0",
-                    "issuer": "https://example.auth0.com",
-                    "jwks_uri": "https://example.auth0.com/.well-known/jwks.json",
-                    "authorization_endpoint": "https://example.auth0.com/authorize",
-                    "token_endpoint": "https://example.auth0.com/oauth/token",
-                    "allowed_domains": ["*.auth0.com"]
-                }
-            ]
-        }"#;
+    fn test_authkit_provider_config() {
+        let provider = ProviderConfig::AuthKit {
+            issuer: "https://example.authkit.app".to_string(),
+            jwks_uri: None,
+            audience: Some("my-api".to_string()),
+        };
 
-        let config: GatewayConfig = serde_json::from_str(json).unwrap();
-        assert_eq!(config.providers.len(), 2);
-        assert_eq!(config.trace_id_header, "X-Request-ID");
-        assert!(config.enabled);
+        // Test serialization
+        let json = serde_json::to_string(&provider).unwrap();
+        assert!(json.contains("authkit"));
+        assert!(json.contains("https://example.authkit.app"));
     }
 
     #[test]
-    fn test_config_parsing_with_auth_disabled() {
-        let json = r#"{
-            "mcp_gateway_url": "http://gateway.internal",
-            "trace_id_header": "X-Request-ID",
-            "enabled": false,
-            "providers": []
-        }"#;
+    fn test_oidc_provider_config() {
+        let provider = ProviderConfig::Oidc {
+            name: "auth0".to_string(),
+            issuer: "https://example.auth0.com".to_string(),
+            jwks_uri: "https://example.auth0.com/.well-known/jwks.json".to_string(),
+            audience: Some("my-api".to_string()),
+            authorization_endpoint: "https://example.auth0.com/authorize".to_string(),
+            token_endpoint: "https://example.auth0.com/oauth/token".to_string(),
+            userinfo_endpoint: None,
+            allowed_domains: vec!["*.auth0.com".to_string()],
+        };
 
-        let config: GatewayConfig = serde_json::from_str(json).unwrap();
+        // Test serialization
+        let json = serde_json::to_string(&provider).unwrap();
+        assert!(json.contains("oidc"));
+        assert!(json.contains("auth0"));
+    }
+
+    #[test]
+    fn test_gateway_config_with_provider() {
+        let config = GatewayConfig {
+            mcp_gateway_url: "http://gateway.internal".to_string(),
+            trace_id_header: "X-Request-ID".to_string(),
+            enabled: true,
+            provider: Some(ProviderConfig::AuthKit {
+                issuer: "https://example.authkit.app".to_string(),
+                jwks_uri: None,
+                audience: None,
+            }),
+        };
+
+        assert!(config.enabled);
+        assert!(config.provider.is_some());
+    }
+
+    #[test]
+    fn test_gateway_config_without_provider() {
+        let config = GatewayConfig {
+            mcp_gateway_url: "http://gateway.internal".to_string(),
+            trace_id_header: "X-Request-ID".to_string(),
+            enabled: false,
+            provider: None,
+        };
+
         assert!(!config.enabled);
-        assert_eq!(config.providers.len(), 0);
-    }
-
-    #[test]
-    fn test_config_parsing_defaults_enabled() {
-        // Test that enabled defaults to true when not specified
-        let json = r#"{
-            "mcp_gateway_url": "http://gateway.internal",
-            "trace_id_header": "X-Request-ID",
-            "providers": []
-        }"#;
-
-        let config: GatewayConfig = serde_json::from_str(json).unwrap();
-        assert!(config.enabled);
+        assert!(config.provider.is_none());
     }
 }

--- a/src/ftl-auth-gateway/src/config.rs
+++ b/src/ftl-auth-gateway/src/config.rs
@@ -48,16 +48,16 @@ impl GatewayConfig {
             .unwrap_or_else(|_| "false".to_string())
             .parse::<bool>()
             .unwrap_or(false);
-        
+
         let mcp_gateway_url = variables::get("auth_gateway_url")
             .unwrap_or_else(|_| "http://ftl-mcp-gateway.spin.internal/mcp-internal".to_string());
-        
-        let trace_id_header = variables::get("auth_trace_header")
-            .unwrap_or_else(|_| "X-Trace-Id".to_string());
+
+        let trace_id_header =
+            variables::get("auth_trace_header").unwrap_or_else(|_| "X-Trace-Id".to_string());
 
         // Read provider configuration
         let provider_type = variables::get("auth_provider_type").unwrap_or_default();
-        
+
         let provider = if provider_type.is_empty() {
             None
         } else {
@@ -76,7 +76,7 @@ impl GatewayConfig {
     fn load_provider_config(provider_type: &str) -> Result<ProviderConfig> {
         let issuer = variables::get("auth_provider_issuer")
             .context("auth_provider_issuer is required when auth_provider_type is set")?;
-        
+
         let audience = variables::get("auth_provider_audience")
             .ok()
             .filter(|s| !s.is_empty());
@@ -86,7 +86,7 @@ impl GatewayConfig {
                 let jwks_uri = variables::get("auth_provider_jwks_uri")
                     .ok()
                     .filter(|s| !s.is_empty());
-                
+
                 Ok(ProviderConfig::AuthKit {
                     issuer,
                     jwks_uri,
@@ -105,7 +105,7 @@ impl GatewayConfig {
                 let userinfo_endpoint = variables::get("auth_provider_userinfo_endpoint")
                     .ok()
                     .filter(|s| !s.is_empty());
-                
+
                 let allowed_domains = variables::get("auth_provider_allowed_domains")
                     .unwrap_or_default()
                     .split(',')
@@ -124,7 +124,10 @@ impl GatewayConfig {
                     allowed_domains,
                 })
             }
-            _ => anyhow::bail!("Unknown auth provider type: {}. Expected 'authkit' or 'oidc'", provider_type)
+            _ => anyhow::bail!(
+                "Unknown auth provider type: {}. Expected 'authkit' or 'oidc'",
+                provider_type
+            ),
         }
     }
 

--- a/src/ftl-auth-gateway/src/lib.rs
+++ b/src/ftl-auth-gateway/src/lib.rs
@@ -53,6 +53,7 @@ async fn handle_request(req: Request) -> Result<impl IntoResponse> {
 
     // Authentication is enabled, proceed with normal auth flow
     let registry = config.build_registry();
+    let provider = registry.providers().first();
 
     // Extract trace ID for structured logging
     let trace_id = get_trace_id(&req, &config.trace_id_header);
@@ -82,7 +83,7 @@ async fn handle_request(req: Request) -> Result<impl IntoResponse> {
         });
 
     // Handle metadata endpoints
-    if let Some(response) = handle_metadata_endpoints(path, &registry, host.as_deref(), &req, &logger) {
+    if let Some(response) = handle_metadata_endpoints(path, provider, host.as_deref(), &req, &logger) {
         return Ok(response);
     }
 
@@ -92,5 +93,5 @@ async fn handle_request(req: Request) -> Result<impl IntoResponse> {
     }
 
     // All other requests require authentication
-    Ok(handle_authenticated_request(req, &config, &registry, host.as_deref(), &trace_id, &logger).await)
+    Ok(handle_authenticated_request(req, &config, provider, host.as_deref(), &trace_id, &logger).await)
 }

--- a/src/ftl-auth-gateway/tests/src/lib.rs
+++ b/src/ftl-auth-gateway/tests/src/lib.rs
@@ -1,29 +1,10 @@
-use spin_test_sdk::{
-    bindings::{fermyon::spin_test_virt, wasi::http},
-    spin_test,
-};
+use spin_test_sdk::{bindings::wasi::http, spin_test};
 
-/// Set up default test configuration
-fn setup_test_config() {
-    spin_test_virt::variables::set(
-        "auth_config",
-        r#"{
-        "mcp_gateway_url": "http://test-gateway.internal/mcp-internal",
-        "trace_id_header": "X-Trace-Id",
-        "providers": [{
-            "type": "authkit",
-            "issuer": "https://test.authkit.app",
-            "jwks_uri": "https://test.authkit.app/.well-known/jwks.json"
-        }]
-    }"#,
-    );
-}
+// Note: Test configuration is provided by spin-test.toml
+// Auth is enabled with an AuthKit provider configured
 
 #[spin_test]
 fn unauthenticated_request() {
-    // Set up test configuration
-    setup_test_config();
-
     // Make request without auth header
     let request = http::types::OutgoingRequest::new(http::types::Headers::new());
     request.set_path_with_query(Some("/mcp")).unwrap();
@@ -31,18 +12,18 @@ fn unauthenticated_request() {
 
     // Should return 401 Unauthorized
     assert_eq!(response.status(), 401);
-    
+
     // Check for WWW-Authenticate header
     let headers = response.headers();
-    let www_auth_exists = headers.entries().iter().any(|(name, _)| name == "www-authenticate");
+    let www_auth_exists = headers
+        .entries()
+        .iter()
+        .any(|(name, _)| name == "www-authenticate");
     assert!(www_auth_exists);
 }
 
 #[spin_test]
 fn options_cors_request() {
-    // Set up test configuration
-    setup_test_config();
-
     // Make OPTIONS request (CORS preflight)
     let request = http::types::OutgoingRequest::new(http::types::Headers::new());
     request.set_method(&http::types::Method::Options).unwrap();
@@ -51,18 +32,19 @@ fn options_cors_request() {
 
     // Should return 204 No Content
     assert_eq!(response.status(), 204);
-    
+
     // Check for CORS headers
     let headers = response.headers();
-    let has_cors = headers.entries().iter().any(|(name, _)| name == "access-control-allow-origin");
+    let has_cors = headers
+        .entries()
+        .iter()
+        .any(|(name, _)| name == "access-control-allow-origin");
     assert!(has_cors);
 }
 
 #[spin_test]
 fn metadata_endpoint() {
-    // Set up test configuration
-    setup_test_config();
-
+    // With the test configuration, we have a provider configured
     // Test /.well-known/oauth-protected-resource endpoint
     let headers = http::types::Headers::new();
     headers.append("host", b"example.com").unwrap();
@@ -73,15 +55,20 @@ fn metadata_endpoint() {
         .unwrap();
     let response = spin_test_sdk::perform_request(request);
 
-    // Should return 500 when no providers configured
-    assert_eq!(response.status(), 500);
+    // Should return 200 when provider is configured
+    assert_eq!(response.status(), 200);
+
+    // Check for proper content type
+    let headers = response.headers();
+    let has_json_content = headers.entries().iter().any(|(name, value)| {
+        name == "content-type" && String::from_utf8_lossy(value).contains("application/json")
+    });
+    assert!(has_json_content);
 }
 
 #[spin_test]
 fn authorization_server_metadata() {
-    // Set up test configuration
-    setup_test_config();
-
+    // With the test configuration, we have a provider configured
     // Test /.well-known/oauth-authorization-server endpoint
     let request = http::types::OutgoingRequest::new(http::types::Headers::new());
     request
@@ -89,22 +76,20 @@ fn authorization_server_metadata() {
         .unwrap();
     let response = spin_test_sdk::perform_request(request);
 
-    // Should return 500 when no providers configured
-    assert_eq!(response.status(), 500);
+    // Should return 200 when provider is configured
+    assert_eq!(response.status(), 200);
+
+    // Check response contains OAuth metadata
+    let headers = response.headers();
+    let has_json_content = headers.entries().iter().any(|(name, value)| {
+        name == "content-type" && String::from_utf8_lossy(value).contains("application/json")
+    });
+    assert!(has_json_content);
 }
 
 #[spin_test]
-fn empty_provider_config() {
-    // Set empty provider list
-    spin_test_virt::variables::set(
-        "auth_config",
-        r#"{
-        "mcp_gateway_url": "http://test-gateway.internal/mcp-internal",
-        "trace_id_header": "X-Trace-Id",
-        "providers": []
-    }"#,
-    );
-
+fn provider_config_works() {
+    // Test that the provider configuration works correctly
     // Make request to metadata endpoint
     let request = http::types::OutgoingRequest::new(http::types::Headers::new());
     request
@@ -112,15 +97,20 @@ fn empty_provider_config() {
         .unwrap();
     let response = spin_test_sdk::perform_request(request);
 
-    // Should return 500 when no providers configured
-    assert_eq!(response.status(), 500);
+    // Should return 200 with configured provider
+    assert_eq!(response.status(), 200);
+
+    // Verify CORS headers are present
+    let headers = response.headers();
+    let has_cors = headers
+        .entries()
+        .iter()
+        .any(|(name, _)| name == "access-control-allow-origin");
+    assert!(has_cors);
 }
 
 #[spin_test]
 fn trace_id_header() {
-    // Set up test configuration
-    setup_test_config();
-
     // Test that trace ID is propagated through requests
     let headers = http::types::Headers::new();
     headers.append("x-trace-id", b"test-trace-123").unwrap();
@@ -131,9 +121,56 @@ fn trace_id_header() {
 
     // Should return 401
     assert_eq!(response.status(), 401);
-    
+
     // Check for trace ID in response
     let response_headers = response.headers();
-    let has_trace = response_headers.entries().iter().any(|(name, _)| name == "x-trace-id");
+    let has_trace = response_headers
+        .entries()
+        .iter()
+        .any(|(name, _)| name == "x-trace-id");
     assert!(has_trace);
+}
+
+#[spin_test]
+fn auth_enabled_requires_token() {
+    // With auth enabled in test config, requests without auth should fail
+    // Make request without auth header
+    let request = http::types::OutgoingRequest::new(http::types::Headers::new());
+    request.set_path_with_query(Some("/mcp")).unwrap();
+    let response = spin_test_sdk::perform_request(request);
+
+    // Should return 401 because auth is required
+    assert_eq!(response.status(), 401);
+
+    // Check for WWW-Authenticate header
+    let headers = response.headers();
+    let www_auth_exists = headers
+        .entries()
+        .iter()
+        .any(|(name, _)| name == "www-authenticate");
+    assert!(www_auth_exists);
+}
+
+#[spin_test]
+fn metadata_endpoint_with_provider() {
+    // Test /.well-known/oauth-protected-resource endpoint
+    let headers = http::types::Headers::new();
+    headers.append("host", b"example.com").unwrap();
+
+    let request = http::types::OutgoingRequest::new(headers);
+    request
+        .set_path_with_query(Some("/.well-known/oauth-protected-resource"))
+        .unwrap();
+    let response = spin_test_sdk::perform_request(request);
+
+    // Should return 200 when provider is configured
+    assert_eq!(response.status(), 200);
+
+    // Check for content type
+    let headers = response.headers();
+    let has_content_type = headers
+        .entries()
+        .iter()
+        .any(|(name, _)| name == "content-type");
+    assert!(has_content_type);
 }

--- a/templates/ftl-auth-gateway/metadata/snippets/component.txt
+++ b/templates/ftl-auth-gateway/metadata/snippets/component.txt
@@ -12,17 +12,26 @@
 #   component = "ftl-mcp-gateway"
 
 # Auth Gateway Configuration
-# By default, authentication is disabled. To enable authentication, override 
-# the auth_config variable when running the application.
+# By default, authentication is disabled. To enable authentication, set
+# auth_enabled = "true" and configure a provider.
 [variables]
-auth_config = { default = '''
-{
-  "mcp_gateway_url": "http://ftl-mcp-gateway.spin.internal/mcp-internal",
-  "trace_id_header": "X-Trace-Id",
-  "enabled": false,
-  "providers": []
-}
-''' }
+# Core auth settings
+auth_enabled = { default = "false" }
+auth_gateway_url = { default = "http://ftl-mcp-gateway.spin.internal/mcp-internal" }
+auth_trace_header = { default = "X-Trace-Id" }
+
+# Provider configuration (required when auth_enabled = "true")
+auth_provider_type = { default = "" }  # "authkit" or "oidc"
+auth_provider_issuer = { default = "" }
+auth_provider_audience = { default = "" }
+
+# OIDC-specific settings (only required for auth_provider_type = "oidc")
+auth_provider_name = { default = "" }
+auth_provider_jwks_uri = { default = "" }
+auth_provider_authorize_endpoint = { default = "" }
+auth_provider_token_endpoint = { default = "" }
+auth_provider_userinfo_endpoint = { default = "" }
+auth_provider_allowed_domains = { default = "" }  # comma-separated list
 
 # Auth Gateway - handles authentication and OAuth discovery
 [[trigger.http]]
@@ -38,10 +47,21 @@ route = "/.well-known/oauth-authorization-server"
 component = "mcp"
 
 [component.mcp]
-source = { registry = "ghcr.io", package = "fastertools:ftl-auth-gateway", version = "0.0.4" }
+source = { registry = "ghcr.io", package = "fastertools:ftl-auth-gateway", version = "0.0.6" }
 allowed_outbound_hosts = ["http://*.spin.internal", "https://*.authkit.app"]
 [component.mcp.variables]
-auth_config = "{% raw %}{{ auth_config }}{% endraw %}"
+auth_enabled = "{% raw %}{{ auth_enabled }}{% endraw %}"
+auth_gateway_url = "{% raw %}{{ auth_gateway_url }}{% endraw %}"
+auth_trace_header = "{% raw %}{{ auth_trace_header }}{% endraw %}"
+auth_provider_type = "{% raw %}{{ auth_provider_type }}{% endraw %}"
+auth_provider_issuer = "{% raw %}{{ auth_provider_issuer }}{% endraw %}"
+auth_provider_audience = "{% raw %}{{ auth_provider_audience }}{% endraw %}"
+auth_provider_name = "{% raw %}{{ auth_provider_name }}{% endraw %}"
+auth_provider_jwks_uri = "{% raw %}{{ auth_provider_jwks_uri }}{% endraw %}"
+auth_provider_authorize_endpoint = "{% raw %}{{ auth_provider_authorize_endpoint }}{% endraw %}"
+auth_provider_token_endpoint = "{% raw %}{{ auth_provider_token_endpoint }}{% endraw %}"
+auth_provider_userinfo_endpoint = "{% raw %}{{ auth_provider_userinfo_endpoint }}{% endraw %}"
+auth_provider_allowed_domains = "{% raw %}{{ auth_provider_allowed_domains }}{% endraw %}"
 
 # MCP Gateway - internal endpoint (protected by auth gateway)
 [[trigger.http]]

--- a/templates/ftl-mcp-server/content/spin.toml
+++ b/templates/ftl-mcp-server/content/spin.toml
@@ -8,45 +8,50 @@ description = "{{project-description}}"
 
 [variables]
 tool_components = { default = "" }
-# ========================================
-# Available auth provider configurations
-# ========================================
 
+# ========================================
+# Auth Gateway Configuration
+# ========================================
+# Authentication is DISABLED by default. To enable, set auth_enabled = "true"
+
+# Core auth settings
+auth_enabled = { default = "false" }
+auth_gateway_url = { default = "http://ftl-mcp-gateway.spin.internal/mcp-internal" }
+auth_trace_header = { default = "X-Trace-Id" }
+
+# Provider configuration (required when auth_enabled = "true")
+auth_provider_type = { default = "" }  # "authkit" or "oidc"
+auth_provider_issuer = { default = "" }
+auth_provider_audience = { default = "" }
+
+# OIDC-specific settings (only required for auth_provider_type = "oidc")
+auth_provider_name = { default = "" }
+auth_provider_jwks_uri = { default = "" }
+auth_provider_authorize_endpoint = { default = "" }
+auth_provider_token_endpoint = { default = "" }
+auth_provider_userinfo_endpoint = { default = "" }
+auth_provider_allowed_domains = { default = "" }  # comma-separated list
+
+# ========================================
+# Example configurations:
+# ========================================
 # AuthKit:
-# {
-#   "type": "authkit",
-#   "issuer": "https://your-tenant.authkit.app",
-#   "audience": "mcp-api"  // optional
-# }
-
-# Generic OIDC (Auth0, Keycloak, etc):
-# {
-#   "type": "oidc",
-#   "name": "auth0",
-#   "issuer": "https://your-domain.auth0.com",
-#   "jwks_uri": "https://your-domain.auth0.com/.well-known/jwks.json",
-#   "authorization_endpoint": "https://your-domain.auth0.com/authorize",
-#   "token_endpoint": "https://your-domain.auth0.com/oauth/token",
-#   "userinfo_endpoint": "https://your-domain.auth0.com/userinfo",  // optional
-#   "audience": "your-api-identifier",  // optional
-#   "allowed_domains": ["*.auth0.com"]  // optional
-# }
+#   auth_enabled = "true"
+#   auth_provider_type = "authkit"
+#   auth_provider_issuer = "https://your-tenant.authkit.app"
+#   auth_provider_audience = "mcp-api"  # optional
 #
-# Auth gateway configuration - auth is DISABLED by default
-# To enable auth, set SPIN_VARIABLE_AUTH_CONFIG with your auth configuration or edit the block below.
-auth_config = { default = '''
-{
-  "mcp_gateway_url": "http://ftl-mcp-gateway.spin.internal/mcp-internal",
-  "trace_id_header": "X-Trace-Id",
-  "enabled": false,
-  "providers": [
-    {
-      "type": "authkit",
-      "issuer": "https://your-tenant.authkit.app"
-    }
-  ]
-}
-''' }
+# Auth0:
+#   auth_enabled = "true"
+#   auth_provider_type = "oidc"
+#   auth_provider_name = "auth0"
+#   auth_provider_issuer = "https://your-domain.auth0.com"
+#   auth_provider_jwks_uri = "https://your-domain.auth0.com/.well-known/jwks.json"
+#   auth_provider_authorize_endpoint = "https://your-domain.auth0.com/authorize"
+#   auth_provider_token_endpoint = "https://your-domain.auth0.com/oauth/token"
+#   auth_provider_userinfo_endpoint = "https://your-domain.auth0.com/userinfo"  # optional
+#   auth_provider_audience = "your-api-identifier"  # optional
+#   auth_provider_allowed_domains = "*.auth0.com"  # optional
 
 # Auth Gateway - handles authentication and OAuth discovery
 [[trigger.http]]
@@ -62,10 +67,21 @@ route = "/.well-known/oauth-authorization-server"
 component = "mcp"
 
 [component.mcp]
-source = { registry = "ghcr.io", package = "fastertools:ftl-auth-gateway", version = "0.0.4" }
+source = { registry = "ghcr.io", package = "fastertools:ftl-auth-gateway", version = "0.0.6" }
 allowed_outbound_hosts = ["http://*.spin.internal", "https://*.authkit.app"]
 [component.mcp.variables]
-auth_config = "{% raw %}{{ auth_config }}{% endraw %}"
+auth_enabled = "{% raw %}{{ auth_enabled }}{% endraw %}"
+auth_gateway_url = "{% raw %}{{ auth_gateway_url }}{% endraw %}"
+auth_trace_header = "{% raw %}{{ auth_trace_header }}{% endraw %}"
+auth_provider_type = "{% raw %}{{ auth_provider_type }}{% endraw %}"
+auth_provider_issuer = "{% raw %}{{ auth_provider_issuer }}{% endraw %}"
+auth_provider_audience = "{% raw %}{{ auth_provider_audience }}{% endraw %}"
+auth_provider_name = "{% raw %}{{ auth_provider_name }}{% endraw %}"
+auth_provider_jwks_uri = "{% raw %}{{ auth_provider_jwks_uri }}{% endraw %}"
+auth_provider_authorize_endpoint = "{% raw %}{{ auth_provider_authorize_endpoint }}{% endraw %}"
+auth_provider_token_endpoint = "{% raw %}{{ auth_provider_token_endpoint }}{% endraw %}"
+auth_provider_userinfo_endpoint = "{% raw %}{{ auth_provider_userinfo_endpoint }}{% endraw %}"
+auth_provider_allowed_domains = "{% raw %}{{ auth_provider_allowed_domains }}{% endraw %}"
 
 # MCP Gateway - internal endpoint (protected by auth gateway)
 [[trigger.http]]


### PR DESCRIPTION
Replace the inline json mess for the auth_config value with a flattened variable structure that enables stuff like

```
SPIN_VARIABLE_AUTH_ENABLED=true SPIN_VARIABLE_AUTH_PROVIDER_TYPE=authkit SPIN_VARIABLE_AUTH_PROVIDER_ISSUER=my.authkit.app spin up
```